### PR TITLE
docs: prefer query params for integrations

### DIFF
--- a/src/content/docs/api/protocols/http.mdx
+++ b/src/content/docs/api/protocols/http.mdx
@@ -134,7 +134,7 @@ The payload response is the current state of the message data
 ### Example: change the external text
 **Request**
 ```bash
-<localhost:4001>/api/message/external/text/new-text
+<localhost:4001>/api/message/external?text=new text
 ```
 
 **Response**
@@ -148,7 +148,7 @@ The payload response is the current state of the message data
             "blackout":false
         },
         "external": {
-            "text":"new-text",
+            "text":"new text",
             "visible":false
         }
     }

--- a/src/content/docs/api/protocols/websockets.mdx
+++ b/src/content/docs/api/protocols/websockets.mdx
@@ -136,7 +136,7 @@ Message: {
     "type": "message", 
     "payload": {
         "external": {
-            "text": "new-text"
+            "text": "new text"
         }
     }
 }
@@ -154,7 +154,7 @@ Message: {
             "blackout":false
             },
         "external":{
-            "text":"new-text",
+            "text":"new text",
             "visible":false
         }
     }


### PR DESCRIPTION
Updating the documentation to refer to query parameters when possible.

It also seems that the query parameters handle escaping spaces well while the path parameters less so 